### PR TITLE
Databases: add app_id argument to #wait and #info

### DIFF
--- a/lib/heroku/api/postgres/backups.rb
+++ b/lib/heroku/api/postgres/backups.rb
@@ -65,10 +65,7 @@ module Heroku
         end
 
         def db_host(app_id)
-          database = heroku_client.addon.list_by_app(app_id).find do |addon|
-            addon['addon_service']['name'] == 'heroku-postgresql'
-          end
-          databases.host_for(database)
+          databases.host_for_app(app_id)
         end
 
         def heroku_client

--- a/lib/heroku/api/postgres/databases.rb
+++ b/lib/heroku/api/postgres/databases.rb
@@ -14,10 +14,10 @@ module Heroku
 
         # original call returns simply a database object, therefore I call the info API.
         # perform_get_request "/client/v11/databases/#{database_id}/wait_status"
-        def wait(database_id, options = { wait_interval: 3 })
+        def wait(app_id, database_id, options = { wait_interval: 3 })
           waiting = true
           while waiting
-            database = info(database_id)
+            database = info(app_id, database_id)
             break unless database[:waiting?]
 
             sleep(options[:wait_interval])
@@ -25,16 +25,29 @@ module Heroku
           database
         end
 
-        def info(database_id)
-          @client.perform_get_request("/client/v11/databases/#{database_id}")
+        def info(app_id, database_id, options = { app_id: nil })
+          @client.perform_get_request("/client/v11/databases/#{database_id}", host: host_for_app(app_id))
         end
 
         def host_for(database)
           starter_plan?(database) ? STARTER_HOST : PRO_HOST
         end
 
+        def host_for_app(app_id)
+          database = heroku_client.addon.list_by_app(app_id).find do |addon|
+            addon['addon_service']['name'] == 'heroku-postgresql'
+          end
+          host_for(database)
+        end
+
         def starter_plan?(database)
           database['plan']['name'].match(/(dev|basic)$/)
+        end
+
+        private
+
+        def heroku_client
+          @heroku_client ||= PlatformAPI.connect_oauth(@client.oauth_client_key)
         end
       end
     end

--- a/spec/heroku/api/postgres/databases_spec.rb
+++ b/spec/heroku/api/postgres/databases_spec.rb
@@ -3,8 +3,9 @@ RSpec.describe Heroku::Api::Postgres::Databases, :vcr do
   let(:client) { Heroku::Api::Postgres.connect_oauth(oauth_token) }
 
   describe '#info' do
+    let(:app_id) { ENV['VALID_APP_ID'] }
     let(:database_id) { ENV['VALID_DATABASE_ID_WITH_SCHEDULES'] }
-    subject(:json_response) { client.databases.info(database_id) }
+    subject(:json_response) { client.databases.info(app_id, database_id) }
 
     context 'server returns 404' do
       let(:oauth_token) { 'invalid_key' }
@@ -23,8 +24,9 @@ RSpec.describe Heroku::Api::Postgres::Databases, :vcr do
   end
 
   describe '#wait' do
+    let(:app_id) { ENV['VALID_APP_ID'] }
     let(:database_id) { ENV['VALID_DATABASE_ID_WITH_SCHEDULES'] }
-    subject(:json_response) { client.databases.wait(database_id, wait_interval: 4) }
+    subject(:json_response) { client.databases.wait(app_id, database_id, wait_interval: 4) }
 
     context 'server returns 200' do
       it 'waits for the given database to be available and returns the database' do


### PR DESCRIPTION
This is a PR to fix issue #5 where `Database` class methods were unable to detect whether or not a database is on a pro plan.

This implementation is not backwards compatible, but it mimics closely the way it was done for `Backups` class. If you prefer backward compatibility more, I can add `app_id` as an option.