### PR TITLE
Fixes #6 - Return latest backup if backup_num is not provided

### DIFF
--- a/lib/heroku/api/postgres/backups.rb
+++ b/lib/heroku/api/postgres/backups.rb
@@ -37,7 +37,14 @@ module Heroku
           @client.perform_post_request("/client/v11/databases/#{database_id}/backups", {}, host: db_host(app_id))
         end
 
-        def url(app_id, backup_num)
+        def url(app_id, backup_num = nil)
+          unless backup_num
+            transfers = list(app_id)
+            last_transfer =
+              transfers.select { |t| t[:succeeded] && t[:to_type] == 'gof3r' }
+                       .max_by { |t| t[:created_at] }
+            backup_num = last_transfer[:num]
+          end
           @client.perform_post_request("/client/v11/apps/#{app_id}/transfers/#{backup_num}/actions/public-url")
         end
 


### PR DESCRIPTION
Fixes #6 - Return latest backup if backup_num is not provided

**Note:** I had created this fix almost 2 years ago. 

Raising pull request to see if the fix still works or someone else could take a look at the changes and reopen another PR