### PR TITLE
Support Ruby 3.0

### DIFF
--- a/lib/heroku/api/postgres/client.rb
+++ b/lib/heroku/api/postgres/client.rb
@@ -39,7 +39,7 @@ module Heroku
         end
 
         def perform_get_request(path, options = {})
-          url = build_uri(path, options)
+          url = build_uri(path, **options)
           req = Net::HTTP::Get.new(url)
           add_auth_headers(req)
           response = start_request(req, url)
@@ -47,7 +47,7 @@ module Heroku
         end
 
         def perform_post_request(path, params = {}, options = {})
-          url = build_uri(path, options)
+          url = build_uri(path, **options)
           req = Net::HTTP::Post.new(url)
           add_auth_headers(req)
           req.body = params.to_json


### PR DESCRIPTION
Addresses https://github.com/coorasse/heroku-api-postgres/issues/17

Ruby 3 introduces some changes which disallow passing a hash as keyword argument(s). This was causing this gem to raise an error when, for instance, trying to list backups:

```
lib/heroku/api/postgres/client.rb:43:in `build_uri': wrong number of arguments (given 2, expected 1) (ArgumentError)
```

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

This small fix uses the double-splat operator to explode the hash. It is still compatible with Ruby <3.0